### PR TITLE
remove endangered palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,6 @@
           <option value="family_name_botanical">Family</option>
           <option value="irrigation_requirements">Water needs</option>
           <option value="shade_production">Shade</option>
-          <option value="iucn_status">Endangered</option>
           <option value="height_min_ft">Height</option>
           <option value="diameter_min_in">Diameter</option>
         </select>
@@ -86,10 +85,6 @@
               <tr>
                 <td>Type:</td>
                 <td id="sidebar-type"></td>
-              </tr>
-              <tr>
-                <td>IUCN Status:</td>
-                <td id="sidebar-iucn-status"></td>
               </tr>
               <tr>
                 <td>IPC Rating:</td>

--- a/public/js/Palettes.js
+++ b/public/js/Palettes.js
@@ -40,20 +40,6 @@ var app = this.app || {};
       'dense'          : '#365BB7',
       'default'        : '#000000'
     },
-    'iucn_status': {
-      'generated'                        : false,
-      'field'                            : 'iucn_status',
-      'Critically Endangered'            : '#33111B',
-      'Endangered'                       : '#5B0020',
-      'Vulnerable'                       : '#7D0027',
-      'Near Threatened'                  : '#B90022',
-      'Lower Risk/conservation dependent': '#DF0007',
-      'Lower Risk/near threatened'       : '#C4C4C4',
-      'Least Concern'                    : '##FC7700',
-      'Data Deficient'                   : '#FDA942',
-      'not listed'                       : '#FFFFFF',
-      'default'                          : '#000000'
-    },
     'height_min_ft': {
       'generated': false,
       'field'    : 'height_min_ft',


### PR DESCRIPTION
this PR will temporarily remove palette/view for iucn_status (endangered attributes), in order to explore the bug with this view (#73). the PR also removes 'Endangered' from the dropdown list under the search bar. I intend to add the option back to the dropdown and palette.js (with some color fixes)
