### PR TITLE
remove Endangered from dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,6 @@
           <option value="family_name_botanical">Family</option>
           <option value="irrigation_requirements">Water needs</option>
           <option value="shade_production">Shade</option>
-          <option value="iucn_status">Endangered</option>
           <option value="height_min_ft">Height</option>
           <option value="diameter_min_in">Diameter</option>
         </select>
@@ -86,10 +85,6 @@
               <tr>
                 <td>Type:</td>
                 <td id="sidebar-type"></td>
-              </tr>
-              <tr>
-                <td>IUCN Status:</td>
-                <td id="sidebar-iucn-status"></td>
               </tr>
               <tr>
                 <td>IPC Rating:</td>


### PR DESCRIPTION
this PR completes the temporary removal of the 'endangered' palette and view from the drop down menu

#73 