### PR TITLE
add English language family names

### DIFF
--- a/public/family_names
+++ b/public/family_names
@@ -1,0 +1,47 @@
+plant family - botanical name,plant family - common name,EOL_ID,EOL - overview
+Adoxaceae,Adoxas,4257,http://eol.org/pages/4257/overview
+Altingiaceae,Sweet-gum,6367079,http://eol.org/pages/6367079/overview
+Anacardiaceae,Sumac,4410,http://eol.org/pages/4410/overview
+Apocynaceae,Dogbane,4280,http://eol.org/pages/4280/overview
+Aquifoliaceae,Holly,4240,http://eol.org/pages/4240/overview
+Araliaceae,Ginseng,5432,http://eol.org/pages/5432/overview
+Araucariaceae,Araucaria,4067,http://eol.org/pages/4067/overview
+Arecaceae,Palm,8193,http://eol.org/pages/8193/overview
+Asparagaceae,Asaparagus,8194,http://eol.org/pages/8194/overview
+Betulaceae,Birch,5528,http://eol.org/pages/5528/overview
+Bignoniaceae,Bignonia,4421,http://eol.org/pages/4421/overview
+Casuarinaceae,Beefwood,4073,http://eol.org/pages/4073/overview
+Celastraceae,Bittersweet,4241,http://eol.org/pages/4241/overview
+Cupressaceae,Cypress,4065,http://eol.org/pages/4065/overview
+Cyatheaceae,Tree-fern,4508,http://eol.org/pages/4508/overview
+Ebenaceae,Ebony,4262,http://eol.org/pages/4262/overview
+Ericaceae,Heather,4267,http://eol.org/pages/4267/overview
+Fabaceae,Legume,4277,http://eol.org/pages/4277/overview
+Fagaceae,Beech,4197,http://eol.org/pages/4197/overview
+Ginkgoaceae,Ginko,4089,http://eol.org/pages/4089/overview
+Juglandaceae,Walnut,4299,http://eol.org/pages/4299/overview
+Lauraceae,Laurel,4308,http://eol.org/pages/4308/overview
+Lythraceae,Loosestrife,4318,http://eol.org/pages/4318/overview
+Magnoliaceae,Magnolia,4194,http://eol.org/pages/4194/overview
+Malvaceae,Mallow,4321,http://eol.org/pages/4321/overview
+Meliaceae,Mahogany,4413,http://eol.org/pages/4413/overview
+Menispermaceae,Moonseed,4376,http://eol.org/pages/4376/overview
+Moraceae,Mulberry,4450,http://eol.org/pages/4450/overview
+Musaceae,Banana,4249,http://eol.org/pages/4249/overview
+Myrtaceae,Myrtle,8095,http://eol.org/pages/8095/overview
+Oleaceae,Olive,4426,http://eol.org/pages/4426/overview
+Pinaceae,Pine,6747,http://eol.org/pages/6747/overview
+Pittosporaceae,Cheesewood,4394,http://eol.org/pages/4394/overview
+Platanaceae,Plane-Tree or Sycamore,4294,http://eol.org/pages/4294/overview
+Podocarpaceae,Podocarp,6748,http://eol.org/pages/6748/overview
+Proteaceae,Protea,4370,http://eol.org/pages/4370/overview
+Quillajaceae,Quillaja,6368716,http://eol.org/pages/6368716/overview
+Rosaceae,Rose,8097,http://eol.org/pages/8097/overview
+Rutaceae,Rue,4414,http://eol.org/pages/4414/overview
+Salicaceae,Willow,4400,http://eol.org/pages/4400/overview
+Sapindaceae,Soapberry,4415,http://eol.org/pages/4415/overview
+Scrophulariaceae,Figwort,4429,http://eol.org/pages/4429/overview
+Simaroubaceae,Quassia or Simaroubaceae,4312,http://eol.org/pages/4312/overview
+Strelitziaceae,Strelitzia,8173,http://eol.org/pages/8173/overview
+Ulmaceae,Elm,4451,http://eol.org/pages/4451/overview
+Verbenaceae,Vervain,4304,http://eol.org/pages/4304/overview


### PR DESCRIPTION
This file will allow documentation of English tree family names to the information panel. The current panel only documents latin names. I copied this csv from the data pipeline repo. 

It might be less complicated to just add the English family names to the current species csv (which feeds into the json file), rather than write some code to look up the English/common family names in this csv, using the latin family names as a key. @ian-r-rose please let me know if you think it'd be simpler for me to just update the species csv. I can definitely do that. 

At the moment, we don't make use of the the fields for EOL IDs and URLs (these would make it possible to have a family information panel with imagery and links to species. those features are included in a [mockup](https://projects.invisionapp.com/share/JSQ7MXBECBA#/screens/350486669)) 