### PR TITLE
move native field out of table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,11 +64,8 @@
             <h1 id="sidebar-common-name"></h1>
             <h2 id="sidebar-botanical-name"></h2>
             <h3>Tree ID: <span id="sidebar-tree-id"></h3>
+            <h4 id="sidebar-nativity"></h4>
             <table>
-              <tr>
-                <td>Nativity:</td>
-                <td id="sidebar-nativity"></td>
-              </tr>
               <tr>
                 <td>Family:</td>
                 <td id="sidebar-tree-family"></td>

--- a/public/index.html
+++ b/public/index.html
@@ -64,7 +64,7 @@
             <h1 id="sidebar-common-name"></h1>
             <h2 id="sidebar-botanical-name"></h2>
             <h3>Tree ID: <span id="sidebar-tree-id"></h3>
-            <h4 id="sidebar-nativity"></h4>
+            <h3 id="sidebar-nativity"></h3>
             <table>
               <tr>
                 <td>Family:</td>


### PR DESCRIPTION
this PR removes the term "nativity" from the sidebar and moves that data out of the table view into the header (it now appears above the data table)