### PR TITLE
add map zoom in/out button #106

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -154,10 +154,6 @@ select.shadow {
   display: none !important;
 }
 
-.leaflet-control-zoom {
-  display: none;
-}
-
 .banner {
   background-color: #41ae76;
   color: #fff;

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -14,6 +14,7 @@ var app = this.app || {};
     var map = L.map('map', {
       center: [34.0215, -118.467],
       zoom: this.zoom,
+      zoomControl: false,
       layers: [
         L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
           attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
@@ -22,6 +23,8 @@ var app = this.app || {};
         })
       ]
     });
+
+    L.control.zoom({position: 'bottomleft'}).addTo(map)
 
     map.on('zoomend', (function() {
       this.zoom = map.getZoom();


### PR DESCRIPTION
What I did:
- disable default zoomControl to change default settings
- add a zoomControl with 'bottomleft' position (puts zoom in/out buttons nicely into the Pacific Ocean)
- remove CSS that was hiding the default zoomControl (probably because it was in upper left and bumping into the filters)