### PR TITLE
reduce fillOpacity to 0.75

### DIFF
--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -64,7 +64,7 @@ var app = this.app || {};
         renderer: RENDERER,
         radius,
         stroke: false,
-        fillOpacity: 1.0,
+        fillOpacity: 0.75,
         fillColor: getFillColor(tree, palette)
       });
       marker.tree = tree;


### PR DESCRIPTION
this PR lowers each circleMarker's fillOpacity to 0.75 in map.js

fixes #122 