### PR TITLE
Only zoom in if we're zoomed out.

### DIFF
--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -88,7 +88,9 @@ var app = this.app || {};
         var markerLocation = marker.getLatLng();
         var newViewLocation = {lat: markerLocation['lat'], lng: markerLocation['lng']};
         newViewLocation['lng'] = newViewLocation['lng'] + 0.0005;
-        this.leafletMap.setView(newViewLocation, 18, {animate: true});
+        var currentZoom = this.leafletMap.getZoom();
+        var targetZoom = currentZoom > 16 ? currentZoom : 18;
+        this.leafletMap.setView(newViewLocation, targetZoom, {animate: true});
 
         if (this.highlightedMarker) { // if one exists, undo its enlargement before enlarging another
           changeCircleMarker(this.highlightedMarker, 'shrink');


### PR DESCRIPTION
If after we zoom in for them, the user has increased or decreased the zoom level by one, don't re-zoom on them. They probably like their current zoom level. At least this is a preference I've found that I have, and thought I'd offer this tweak. Take it or leave it, no problem either way!