### PR TITLE
adds "vacant site" to select2 dropdown menu

### DIFF
--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -25,10 +25,7 @@ var app = this.app || {};
 
     function counter(hashmap, tree) {
         var tree_key = tree['name_common'].concat([' (', tree['name_botanical'], ')'].join(''));
-        if (tree['name_common'] === 'Vacant Site'){
-
-        }
-        else if (hashmap.has(tree_key)) {
+        if (hashmap.has(tree_key)) {
             var currentCount = hashmap.get(tree_key);
             currentCount['count'] += 1;
             hashmap.set(tree_key,  currentCount);


### PR DESCRIPTION
this PR removes the line of code that excluded vacant sites from the select2 dropdown. other types of vacant sites (asphalted well, stump, etc) are already included as options in the select2 list

fixes #131 