### PR TITLE
add error message if browser does not enable location services

### DIFF
--- a/public/js/Geolocation.js
+++ b/public/js/Geolocation.js
@@ -30,7 +30,7 @@ var app = this.app || {};
                 navigator.geolocation.getCurrentPosition(zoomFromPosition);
             }
             else {
-                alert('Please enable location access to your browser to use this feature')
+                alert('To use this feature, please enable location services.')
             }
         });
         this.placesAutocomplete.on('change', function(event){

--- a/public/js/Geolocation.js
+++ b/public/js/Geolocation.js
@@ -26,7 +26,12 @@ var app = this.app || {};
         var clonedPlacesPinWithoutEventListenters = placesPinElement.cloneNode(true);
         placesPinElement.parentNode.replaceChild(clonedPlacesPinWithoutEventListenters, placesPinElement);
         $('.ap-icon-pin').on('click', function() {
-            navigator.geolocation.getCurrentPosition(zoomFromPosition);
+            if (navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(zoomFromPosition);
+            }
+            else {
+                alert('Please enable location access to your browser to use this feature')
+            }
         });
         this.placesAutocomplete.on('change', function(event){
             zoomToLatLng(event.suggestion.latlng);


### PR DESCRIPTION
fixes #153 

the issue described in #153 is actually due to a block on location services in the mobile browser. this PR adds a pop-up error message so that a user will know whether or location services are enabled