### PR TITLE
switch default view (for now) to species

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -26,7 +26,7 @@ var app = this.app || {};
   }
 
   function setData(trees) {
-    _map.setTrees(trees, module.palettes['nativity']);
+    _map.setTrees(trees, module.palettes['name_common']);
     _speciesFilter.setSpecies(_speciesFilter.selectFormatter(trees));
     document.getElementById('loading').classList.add('hidden');
   }


### PR DESCRIPTION
# Motivation and context
When a user loads the map to a specific point (eg [this tree](https://public-tree-map.surge.sh/?id=10936680)), it's easier for the user to understand the map if the markers are automatically colored by species or family.

# Screenshots
| before |
|---|
|![Screen Shot 2019-08-30 at 3 43 50 PM](https://user-images.githubusercontent.com/22624609/64054806-9bde6e00-cb3d-11e9-8953-af9cc89f539a.png)

| after |
|---|
|![Screen Shot 2019-08-30 at 3 44 02 PM](https://user-images.githubusercontent.com/22624609/64054795-8c5f2500-cb3d-11e9-80c3-2dfefa72998d.png)

# What I did
changed default view in main.js to 'name_common' 
