### PR TITLE
limit color filter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -57,13 +57,13 @@
         <!-- Color Filter -->
         <select id="color-filter" class="shadow">
           <option value="name_common" selected>Species</option>
-          <option value="nativity">CA native</option>
           <option value="family_name_botanical">Family</option>
-          <option value="irrigation_requirements">Water needs</option>
-          <option value="shade_production">Shade</option>
+          <option value="nativity">CA native</option>
+          <!-- <option value="irrigation_requirements">Water needs</option> //pending updated equations to display water needs--> 
+          <!-- <option value="shade_production">Shade</option> //pending updated equations to display shade production -->
           <option value="iucn_status">Endangered</option>
           <option value="height_min_ft">Height</option>
-          <option value="ipc_rating">Invasive</option>
+          <!-- <option value="ipc_rating">Invasive</option> //combined with data about CA native trees-->
         </select>
 
         <select id="species-filter" name="state" multiple="multiple">

--- a/public/index.html
+++ b/public/index.html
@@ -59,11 +59,8 @@
           <option value="name_common" selected>Species</option>
           <option value="family_name_botanical">Family</option>
           <option value="nativity">CA native</option>
-          <!-- <option value="irrigation_requirements">Water needs</option> //pending updated equations to display water needs--> 
-          <!-- <option value="shade_production">Shade</option> //pending updated equations to display shade production -->
           <option value="iucn_status">Endangered</option>
           <option value="height_min_ft">Height</option>
-          <!-- <option value="ipc_rating">Invasive</option> //combined with data about CA native trees-->
         </select>
 
         <select id="species-filter" name="state" multiple="multiple">


### PR DESCRIPTION
hides water needs, shade, and invasive options from color filter

# Motivation and context
<!-- please describe what problem your issue is solving -->
after some conversations with the city urban forest staff and Poliana Raymer at SMC, it seems like we need to be more detailed with visually representing water and shade (eg consider tree height and diamater). we also decided to try combining the invasive and CA native views (the data aren't yet reformatted). Jess suggests that fewer options will translate better into a button-type filter bar

# Screenshots
| before | 
|---|
| <!-- before screenshot here --> | 
![Screen Shot 2019-08-30 at 5 06 31 PM](https://user-images.githubusercontent.com/22624609/64056573-0c3ebc80-cb49-11e9-9c4f-d62ce12b9ee4.png)

| after |
|---|
| <!-- after screenshot here --> |
![Screen Shot 2019-08-30 at 5 06 54 PM](https://user-images.githubusercontent.com/22624609/64056575-152f8e00-cb49-11e9-8879-8fcf4926cb2c.png)

# What I did
- <!-- list summary of changes made in this PR --> I deleted the lines for water needs, shade, and invasive options from the color filter in index.html file
