### PR TITLE
update native/invasive palette, sidebar text

### DIFF
--- a/public/js/Palettes.js
+++ b/public/js/Palettes.js
@@ -8,6 +8,9 @@ var app = this.app || {};
       'field'    : 'nativity',
       'native'   : { 'color': '#40AD75', 'title': 'Native to California' },
       'exotic'   : { 'color': '#fc9272', 'title': 'Not Native to California' },
+      'moderate' : { 'color': '#BC0000', 'title': 'Moderate' },
+      'watch'    : { 'color': '#FF8202', 'title': 'Watch' },
+      'limited'  : { 'color': '#FE0000', 'title': 'Limited' },
       'default'  : '#bdbdbd'
     },
     'name_common': {
@@ -63,14 +66,6 @@ var app = this.app || {};
       '45'       : { 'color': '#3E83BF', 'title': '45 ft' },
       '60'       : { 'color': '#2E5C85', 'title': '60 ft' },
       'default'  : '#000000'
-    },
-    'ipc_rating': {
-      'generated': false,
-      'field'    : 'ipc_rating',
-      'moderate' : { 'color': '#BC0000', 'title': 'Moderate' },
-      'watch'    : { 'color': '#FF8202', 'title': 'Watch' },
-      'limited'  : { 'color': '#FE0000', 'title': 'Limited' },
-      'default'  : '#bdbdbd'
     },
   }
 })(app);

--- a/public/js/Sidebar.js
+++ b/public/js/Sidebar.js
@@ -140,6 +140,12 @@ a2a_config.templates = a2a_config.templates || {};
       return "This tree is native to California";
     } else if ("exotic" === nativity.toLowerCase()) {
       return "This tree isn't native to California";
+    } else if ("moderate" === nativity.toLowerCase()) {
+      return "This tree isn't native to California";
+    } else if ("watch" === nativity.toLowerCase()) {
+      return "This tree isn't native to California";
+    } else if ("limited" === nativity.toLowerCase()) {
+      return "This tree isn't native to California";      
     } else {
       return "Unknown";
     }


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #171 

# Motivation and context
- <!-- please describe what problem your issue is solving --> this PR updates the "CA native" palette to include plants designated as invasive/watch by cal ipc. I haven't updated the colors in the CA native palette, I just included the relevant cal ipc fields and used the existing colors. 
- colors will need an update (see #150)

# Screenshots
| before |
|---|
| <!-- before screenshot here --> 
![Screen Shot 2019-08-30 at 9 27 46 PM](https://user-images.githubusercontent.com/22624609/64059279-08716100-cb6e-11e9-9e31-c47ec65945c8.png)|

| after |
|---|
|![Screen Shot 2019-08-30 at 9 27 01 PM](https://user-images.githubusercontent.com/22624609/64059272-eaa3fc00-cb6d-11e9-8a6a-af649bdcb6ef.png)|

# What I did
- I moved the moved the "invasive" palette into the "CA native" palette 
- I updated the conditions in sidebar.js so that the cal-ipc designated species are identified in the relevant info panels as exotic (not native to california) rather than "unknown"