### PR TITLE
move image credit

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -111,8 +111,15 @@ html, body {
 #sidebar-image-credit {
   position: absolute;
   bottom: 0;
-  left: 0;
-  color: #fff;
+  right: 0;
+  font-family: Lato;
+  font-size: 12px;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #ffffff;
   background: rgba(0, 0, 0, 0.5);
   padding: 5px 12px;
 }


### PR DESCRIPTION
adjust sidebar image credit to (at least somewhat) match zeplin

# Motivation and context
<!-- please describe what problem your issue is solving -->
the image credit in the infopanel in zeplin is on the opposite side

# Screenshots
| before | 
|---|
| <!-- before screenshot here --> | 
![Screen Shot 2019-09-17 at 11 30 42 AM](https://user-images.githubusercontent.com/22624609/65069118-e6822780-d93e-11e9-81d8-8a18ca917fc0.png)

| after |
|---|
| <!-- after screenshot here --> |
![Screen Shot 2019-09-17 at 11 30 19 AM](https://user-images.githubusercontent.com/22624609/65069142-eda93580-d93e-11e9-8608-0dd59bc5cd7e.png)

# What I did
- <!-- list summary of changes made in this PR -->
I switched the image credit from L to R and added some formatting
