### PR TITLE
adjust toolbar formatting

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -31,9 +31,11 @@ html, body {
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
-  height: auto;
+  height: 36px;
   padding: 8px;
   width: 100%;
+  font-size: 14px;
+  font-color: #777777;
 }
 
 #search input {
@@ -260,6 +262,7 @@ html, body {
   border: solid 1px #cccccc;
   cursor: pointer; /* Pointer/hand icon */
   float: left; /* Float the buttons side by side */
+  font-size: 14px;
 }
 .btn-group button:focus {
   outline: 0;
@@ -291,19 +294,19 @@ html, body {
   height: 36px;
 }
 .address-container {
-  width: 65%;
+  width: 45%;
 }
 .ap-input-icon {
   right: 10px;
-}
-.ap-icon-clear {
-  right: 40px;
 }
 .species-filter-container {
   width: 30%;
 }
 .select2-container {
   width: 100% !important;
+  height: 36px;
+  font-size: 14px;
+  font-color: #777777;
 }
 .select2-selection {
   padding: 3px; 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -299,6 +299,9 @@ html, body {
 .ap-input-icon {
   right: 10px;
 }
+.ap-icon-clear {
+  right: 40px;
+}
 .species-filter-container {
   width: 30%;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
           <div id="color-filter" class="btn-group">
             <button id="species-button-species" class="species-button active" value="name_common">Species</button>
             <button id="species-button-family" class="species-button" value="family_name_botanical">Family</button>
-            <button class="species-button" value="nativity">CA native</button>
+            <button class="species-button" value="nativity">CA Native</button>
             <button class="species-button" value="iucn_status">Endangered</button>
           </div>
         </div>


### PR DESCRIPTION
<!-- if the linked issue should remain open after your PR is merged: -->
addresses #200 

# Motivation and context
<!-- please describe what problem your issue is solving -->
this pr adjusts the heights and font sizes for the two search bars (for desktop users)

# Screenshots
| before | after |
|---|---|
| ![Screen Shot 2019-09-26 at 8 41 42 PM](https://user-images.githubusercontent.com/22624609/65740575-1a2b2300-e09e-11e9-8364-70c12adac275.png)<!-- before screenshot here --> | ![Screen Shot 2019-09-26 at 8 33 41 PM](https://user-images.githubusercontent.com/22624609/65740524-ec45de80-e09d-11e9-9924-ba01665b1e63.png)
<!-- after screenshot here --> |

# What I did
- <!-- list summary of changes made in this PR -->
- narrowed the width of the algolia address search bar (temporarily, to accommodate larger text size in the buttons)
- made the search bars uniform height
- made the text across the toolbar a uniform size
