### PR TITLE
set sidebar to be 25% width of window

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -229,7 +229,7 @@ html, body {
 #map {
   height: 100%;
   position: absolute;
-  width: calc(100% - 440px);
+  width: 75%;
 }
 
 #loading {
@@ -420,7 +420,7 @@ select.shadow {
   }
 
   #toolbar {
-    flex-basis: calc(96% - 440px);
+    flex-basis: calc(96% - 25%);
     border-radius: 4px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     background-color: #fff;
@@ -430,13 +430,13 @@ select.shadow {
   }
 
   #sidebar {
-    flex-basis: 440px;
+    flex-basis: 25%;
     height: calc(100%);
     position: relative;
   }
 
   #map {
-    flex-basis: calc(100% - 440px);
+    flex-basis: 75%;
   }
 
   .sidebar-image {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -229,7 +229,7 @@ html, body {
 #map {
   height: 100%;
   position: absolute;
-  width: 72%;
+  width: 70%;
 }
 
 #loading {
@@ -423,7 +423,7 @@ select.shadow {
   }
 
   #toolbar {
-    flex-basis: calc(96% - 28%);
+    flex-basis: calc(96% - 30%);
     border-radius: 4px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     background-color: #fff;
@@ -433,13 +433,13 @@ select.shadow {
   }
 
   #sidebar {
-    flex-basis: 28%;
+    flex-basis: 30%;
     height: calc(100%);
     position: relative;
   }
 
   #map {
-    flex-basis: 72%;
+    flex-basis: 70%;
   }
 
   .sidebar-image {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -229,7 +229,7 @@ html, body {
 #map {
   height: 100%;
   position: absolute;
-  width: 75%;
+  width: 72%;
 }
 
 #loading {
@@ -359,9 +359,12 @@ select.shadow {
 .banner {
   background-color: #41ae76;
   color: #fff;
-  font-size: 25px;
   line-height: 1;
-  padding: 18px 18px 25px 20px;
+  font-size: 14px;
+  padding: 17px 17px 17px 17px;
+  font-weight: bold;
+  font-style: normal;
+  letter-spacing: 1px;
   text-align: center;
 }
 #rightButton button{
@@ -420,7 +423,7 @@ select.shadow {
   }
 
   #toolbar {
-    flex-basis: calc(96% - 25%);
+    flex-basis: calc(96% - 28%);
     border-radius: 4px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
     background-color: #fff;
@@ -430,17 +433,17 @@ select.shadow {
   }
 
   #sidebar {
-    flex-basis: 25%;
+    flex-basis: 28%;
     height: calc(100%);
     position: relative;
   }
 
   #map {
-    flex-basis: 75%;
+    flex-basis: 72%;
   }
 
   .sidebar-image {
-    min-height: 250px;
+    min-height: 220px;
   }
 
   

--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
 
       <!-- Sidebar -->
       <div id="sidebar" class="box shadow">
-        <div class="banner">Santa Monica Public Tree Map</div>
+        <div class="banner">SANTA MONICA PUBLIC TREE MAP</div>
         <div id="sidebar-vacant">
           <button id="sidebar-vacant-close-button">x</button>
           <div id="sidebar-vacant-content">


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
make sidebar narrower #202

<!-- if the linked issue should remain open after your PR is merged: -->
addresses #<!-- issue number here -->

# Motivation and context
<!-- please describe what problem your issue is solving -->
the sidebar takes up a lot of room on the website, limits how much map a user can see. 

# Screenshots
| before | after |
|---|---|
| <!-- before screenshot here -->![Screen Shot 2019-10-06 at 1 12 17 PM](https://user-images.githubusercontent.com/22624609/66275189-11271800-e83b-11e9-8985-77e7de1ca632.png) | <!-- after screenshot here -->![Screen Shot 2019-10-06 at 1 25 13 PM](https://user-images.githubusercontent.com/22624609/66275370-cefed600-e83c-11e9-8204-318d8f0fdb95.png)|

# What I did
- <!-- list summary of changes made in this PR --> narrows sidebar 
-  adjusts banner text and image formatting to look more like the zeplin mockup
