### PR TITLE
color keys for select2 options/selections

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -398,6 +398,12 @@ select.shadow {
 }
 #leftButton:hover button:focus {outline:0;}
 
+.color-key {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
 
 
 @media only screen and (max-width: 850px) {

--- a/public/js/ColorFilter.js
+++ b/public/js/ColorFilter.js
@@ -5,15 +5,15 @@ var app = this.app || {};
   function ColorFilter(map, legend) {
     this.map    = map;
     this.legend = legend;
+    this.filter = document.getElementsByClassName('species-button');
 
-    var filter = document.getElementsByClassName('species-button');
     $('.species-button').on('click', (function(e) {
       $('.species-button').removeClass('active');
       $(e.target).addClass('active');
       this.onChange(e.target.value);
     }).bind(this));
 
-    this.onChange(filter.value);
+    this.onChange(this.filter.value);
   }
 
   ColorFilter.prototype.onChange = function(key) {

--- a/public/js/Legend.js
+++ b/public/js/Legend.js
@@ -7,13 +7,25 @@ var app = this.app || {};
  */
 (function(module) {
 
-  function Legend() {
+  function Legend(map, speciesFilter) {
     // TODO: Store references to views
+    this.map = map;
+    this.speciesFilter = speciesFilter;
+  }
+
+  Legend.prototype.setSelectLegend = function(formattedSpecies, palette) {
+    return formattedSpecies.map(
+      tree => ({...tree, legend: this.map.getFillColor(tree, palette)})
+    );
   }
 
   /** Invoked with an object that contains data that can be used to render a legend */
-  Legend.prototype.setLegend = function(legend) {
+  Legend.prototype.setLegend = function(palette) {
     // TODO: Render legend
+    if(palette) {
+      var newPaletteFilter = this.setSelectLegend(this.speciesFilter.species, palette);
+      this.speciesFilter.setSpecies(newPaletteFilter);
+    }
   }
 
   // Exports

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -11,6 +11,7 @@ var app = this.app || {};
     this.highlightedMarker = null;
     this.trees   = [];
     this.zoom    = 14.2;
+    this.fillOpacity = 0.75;
     this.selected = new Set();
     this.urlParams = new URLSearchParams(window.location.search);
 
@@ -91,8 +92,8 @@ var app = this.app || {};
         renderer: RENDERER,
         radius,
         stroke: false,
-        fillOpacity: 0.75,
-        fillColor: getFillColor(tree, palette)
+        fillOpacity: this.fillOpacity,
+        fillColor: this.getFillColor(tree, palette)
       });
       marker.tree = tree;
       marker.bindPopup(tree.name_common, {closeButton: false});
@@ -134,9 +135,10 @@ var app = this.app || {};
 
   Map.prototype.setPalette = function(palette) {
     this.palette = palette;
+    var realThis = this;
     this.markers.eachLayer(function(marker) {
       marker.setStyle({
-        fillColor: getFillColor(marker.tree, palette)
+        fillColor: realThis.getFillColor(marker.tree, palette)
       });
     });
     if (this.highlightedMarker) {
@@ -194,7 +196,7 @@ var app = this.app || {};
     }
   }
 
-  function getFillColor(tree, palette) {
+  Map.prototype.getFillColor = function(tree, palette) {
     if (palette.generated) {
       return generateColor(tree[palette.field]);
     }

--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -58,7 +58,7 @@ var app = this.app || {};
     SpeciesFilter.prototype.selectFormatter = function(trees){
         countedTrees = trees.reduce(counter, new Map());
         var countedTreesArray = Array.from(countedTrees).map(x => x[1]);
-        return countedTreesArray.map(
+        var selectArray = countedTreesArray.map(
             (tree, index) => ({
                 id: index, 
                 text: treeToStr(tree), 
@@ -69,6 +69,7 @@ var app = this.app || {};
                 iucn_status: tree.iucnStatus
             })
         );
+        return Array.from(selectArray).sort(treeCompareAlpha);
     };
 
     function treeCompareAlpha(treeA, treeB){
@@ -82,7 +83,7 @@ var app = this.app || {};
     }
 
     SpeciesFilter.prototype.setSpecies = function(species) {
-        this.species = Array.from(species).sort(treeCompareAlpha);
+        this.species = species;
         selectFilter.select2({
             placeholder: 'Start typing a species name',
             data: this.species,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -10,9 +10,9 @@ var app = this.app || {};
   function init() {
     _sidebar       = new module.Sidebar();
     _map           = new module.Map(_sidebar);
-    _legend        = new module.Legend();
-    _colorFilter   = new module.ColorFilter(_map, _legend);
     _speciesFilter = new module.SpeciesFilter(_map);
+    _legend        = new module.Legend(_map, _speciesFilter);
+    _colorFilter   = new module.ColorFilter(_map, _legend);
     _geolocation = new module.Geolocation(_map);
 
     _sidebar.showDefault();
@@ -26,8 +26,11 @@ var app = this.app || {};
   }
 
   function setData(trees) {
+    var defaultPalette = module.palettes[_colorFilter.filter.item(0).value];
+    var formattedSelect = _legend.setSelectLegend(_speciesFilter.selectFormatter(trees), defaultPalette);
+
     _map.setTrees(trees, module.palettes['name_common']);
-    _speciesFilter.setSpecies(_speciesFilter.selectFormatter(trees));
+    _speciesFilter.setSpecies(formattedSelect);
     document.getElementById('loading').classList.add('hidden');
   }
 


### PR DESCRIPTION
addresses #172 

# Screenshots
<table>
  <tr>
    <td>before</td><td>after</td>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/20414905/66387919-bf37eb00-ea10-11e9-8ddd-7f520885f5ca.png" width="100%"/>
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/20414905/66388173-4b4a1280-ea11-11e9-9199-bf6a3a8024c1.png" width="100%"/>
    </td>
  </tr>
</table>

# What I did
- color keys on select2 options/selections
- change color keys to match markers when changing group color filter (excluding unused heritage button)

Also I just noticed there are white color keys when grouping by endangered. Will the color scheme for the select2 need to be tweaked? Or will it be made redundant later?
