### PR TITLE
Heritage group filter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -68,7 +68,7 @@
             <button id="species-button-species" class="species-button active" value="name_common">Species</button>
             <button id="species-button-family" class="species-button" value="family_name_botanical">Family</button>
             <button class="species-button" value="nativity">CA Native</button>
-            <button id="species-button" value=>Heritage</button>
+            <button id="species-button-heritage" class="species-button" value="heritage">Heritage</button>
             <button class="species-button" value="iucn_status">Endangered</button>
           </div>
         </div>

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -41,22 +41,26 @@ var app = this.app || {};
   Map.prototype.setFilter = function(selections) {
     var bounds = this.leafletMap.getBounds();
     var center = bounds.getCenter();
+    var realThis = this;
     var closestDistance;
     var closestPoint;
 
     this.selected = selections;
     this.redraw();
-    this.markers.eachLayer(function(layer) {
+    this.markers.eachLayer(function(marker) {
       if(selections.size > 0) {
-        var position = layer.getLatLng();
+        var position = marker.getLatLng();
         var distance = center.distanceTo(position);
-        if(distance < closestDistance || !closestDistance) {
-          closestDistance = distance;
-          closestPoint = L.latLng(position);
+        if (distance < closestDistance || !closestDistance) {
+          if ( !(realThis.palette.field === 'heritage' && !marker.tree.heritage)) {
+            closestDistance = distance;
+            closestPoint = L.latLng(position);
+          }
         }
       }
     });
     this.leafletMap.fitBounds(bounds.extend(closestPoint));
+    setMarkerSize.call(this, this.zoom);
   }
 
   Map.prototype.setTrees = function(trees, palette) {

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -41,6 +41,7 @@ var app = this.app || {};
   Map.prototype.setFilter = function(selections) {
     var bounds = this.leafletMap.getBounds();
     var center = bounds.getCenter();
+    var palette = this.palette;
     var closestDistance;
     var closestPoint;
 
@@ -51,8 +52,10 @@ var app = this.app || {};
         var position = marker.getLatLng();
         var distance = center.distanceTo(position);
         if (distance < closestDistance || !closestDistance) {
-          closestDistance = distance;
-          closestPoint = L.latLng(position);
+          if ( !(palette.field === 'heritage' && !marker.tree.heritage)) {
+            closestDistance = distance;
+            closestPoint = L.latLng(position);
+          }
         }
       }
     });
@@ -83,14 +86,7 @@ var app = this.app || {};
 
     this.markers.clearLayers();
     if (selectedCommonNames.size > 0){
-      filter = function(tree) {
-        if (selectedCommonNames.has(tree['name_common'])) {
-          if ( !(palette.field === 'heritage' && !tree.heritage)) {
-            return true;
-          }
-        }
-        return false;
-      }
+      filter = tree => selectedCommonNames.has(tree['name_common']);
     }
     else {
       filter = tree => tree;
@@ -145,7 +141,6 @@ var app = this.app || {};
     this.palette = palette;
     var realThis = this;
 
-    this.redraw();
     setMarkerSize.call(this, this.zoom); 
     this.markers.eachLayer(function(marker) {
       marker.setStyle({
@@ -153,6 +148,7 @@ var app = this.app || {};
       });
     });
     if (this.highlightedMarker) {
+      changeCircleMarker(this.highlightedMarker, 'enlarge');
       changeCircleMarker(this.highlightedMarker, 'recolor');
     }
   }

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -136,6 +136,8 @@ var app = this.app || {};
   Map.prototype.setPalette = function(palette) {
     this.palette = palette;
     var realThis = this;
+
+    setMarkerSize.call(this, this.zoom); 
     this.markers.eachLayer(function(marker) {
       marker.setStyle({
         fillColor: realThis.getFillColor(marker.tree, palette)
@@ -143,6 +145,25 @@ var app = this.app || {};
     });
     if (this.highlightedMarker) {
       changeCircleMarker(this.highlightedMarker, 'recolor');
+    }
+  }
+
+  function setMarkerSize(zoom) {
+    var radius = Math.max(1, zoom - 13);
+    
+    if (this.palette && this.palette.field === 'heritage') {
+      this.markers.eachLayer(function(marker) {
+        if (marker.tree.heritage) {
+          marker.bringToFront();
+          marker.setRadius(radius + 4);
+        } else {
+          marker.setRadius(radius);
+        }
+      });
+    } else {
+      this.markers.eachLayer(function(marker) {
+        marker.setRadius(radius);
+      });
     }
   }
 
@@ -154,9 +175,7 @@ var app = this.app || {};
   }
 
   function onZoomChanged(zoom) {
-    this.markers.eachLayer(function(marker) {
-      marker.setRadius(Math.max(1, zoom - 13));
-    });
+    setMarkerSize.call(this, zoom); 
     if (this.highlightedMarker) {
       changeCircleMarker(this.highlightedMarker, 'enlarge');
     }

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -41,7 +41,6 @@ var app = this.app || {};
   Map.prototype.setFilter = function(selections) {
     var bounds = this.leafletMap.getBounds();
     var center = bounds.getCenter();
-    var palette = this.palette;
     var closestDistance;
     var closestPoint;
 
@@ -52,10 +51,8 @@ var app = this.app || {};
         var position = marker.getLatLng();
         var distance = center.distanceTo(position);
         if (distance < closestDistance || !closestDistance) {
-          if ( !(palette.field === 'heritage' && !marker.tree.heritage)) {
-            closestDistance = distance;
-            closestPoint = L.latLng(position);
-          }
+          closestDistance = distance;
+          closestPoint = L.latLng(position);
         }
       }
     });

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -162,12 +162,13 @@ var app = this.app || {};
 
   function setMarkerSize(zoom) {
     var radius = Math.max(1, zoom - 13);
+    var palette = this.palette;
     
-    if (this.palette && this.palette.field === 'heritage') {
+    if (palette && palette.field === 'heritage') {
       this.markers.eachLayer(function(marker) {
         if (marker.tree.heritage) {
           marker.bringToFront();
-          marker.setRadius(radius + 4);
+          marker.setRadius(radius + palette.markerSize);
         } else {
           marker.setRadius(radius);
         }

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -41,7 +41,7 @@ var app = this.app || {};
   Map.prototype.setFilter = function(selections) {
     var bounds = this.leafletMap.getBounds();
     var center = bounds.getCenter();
-    var realThis = this;
+    var palette = this.palette;
     var closestDistance;
     var closestPoint;
 
@@ -52,7 +52,7 @@ var app = this.app || {};
         var position = marker.getLatLng();
         var distance = center.distanceTo(position);
         if (distance < closestDistance || !closestDistance) {
-          if ( !(realThis.palette.field === 'heritage' && !marker.tree.heritage)) {
+          if ( !(palette.field === 'heritage' && !marker.tree.heritage)) {
             closestDistance = distance;
             closestPoint = L.latLng(position);
           }
@@ -86,7 +86,14 @@ var app = this.app || {};
 
     this.markers.clearLayers();
     if (selectedCommonNames.size > 0){
-      filter = tree => selectedCommonNames.has(tree['name_common']);
+      filter = function(tree) {
+        if (selectedCommonNames.has(tree['name_common'])) {
+          if ( !(palette.field === 'heritage' && !tree.heritage)) {
+            return true;
+          }
+        }
+        return false;
+      }
     }
     else {
       filter = tree => tree;
@@ -141,6 +148,7 @@ var app = this.app || {};
     this.palette = palette;
     var realThis = this;
 
+    this.redraw();
     setMarkerSize.call(this, this.zoom); 
     this.markers.eachLayer(function(marker) {
       marker.setStyle({

--- a/public/js/Palettes.js
+++ b/public/js/Palettes.js
@@ -71,7 +71,8 @@ var app = this.app || {};
       'generated' : false,
       'field'     : 'heritage',
       'true'      : { 'color': '#1b499d', 'title': 'true' },
-      'false'     : { 'color': '#FFFFFF', 'title': 'false' }
+      'false'     : { 'color': '#FFFFFF', 'title': 'false' },
+      'markerSize': 4,
     },
   }
 })(app);

--- a/public/js/Palettes.js
+++ b/public/js/Palettes.js
@@ -67,5 +67,11 @@ var app = this.app || {};
       '60'       : { 'color': '#2E5C85', 'title': '60 ft' },
       'default'  : '#000000'
     },
+    'heritage': {
+      'generated' : false,
+      'field'     : 'heritage',
+      'true'      : { 'color': '#1b499d', 'title': 'true' },
+      'false'     : { 'color': '#FFFFFF', 'title': 'false' }
+    },
   }
 })(app);

--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -105,14 +105,8 @@ var app = this.app || {};
             </span>'
         );
         var alpha = Math.round(255 * this.fillOpacity).toString(16);
-        var colorKey = formatted.find(".color-key");
         
-        if (this.palette.field === 'heritage') {
-            colorKey.addClass("hidden");
-        } else {
-            colorKey.removeClass("hidden");
-        }
-        colorKey.css("background-color", selection.legend + alpha);
+        formatted.find(".color-key").css("background-color", selection.legend + alpha);
         formatted.find(".select2-selection-text").text(selection.text);
         return formatted;
     }

--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -29,9 +29,6 @@ var app = this.app || {};
         if (hashmap.has(tree_key)) {
             var currentCount = hashmap.get(tree_key);
             currentCount['count'] += 1;
-            if (tree.heritage) {
-                currentCount.heritage = true;
-            }
             hashmap.set(tree_key,  currentCount);
         }
         else {
@@ -105,8 +102,14 @@ var app = this.app || {};
             </span>'
         );
         var alpha = Math.round(255 * this.fillOpacity).toString(16);
+        var colorKey = formatted.find(".color-key");
         
-        formatted.find(".color-key").css("background-color", selection.legend + alpha);
+        if (this.palette.field === 'heritage') {
+            colorKey.addClass("hidden");
+        } else {
+            colorKey.removeClass("hidden");
+        }
+        colorKey.css("background-color", selection.legend + alpha);
         formatted.find(".select2-selection-text").text(selection.text);
         return formatted;
     }

--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -105,8 +105,14 @@ var app = this.app || {};
             </span>'
         );
         var alpha = Math.round(255 * this.fillOpacity).toString(16);
+        var colorKey = formatted.find(".color-key");
         
-        formatted.find(".color-key").css("background-color", selection.legend + alpha);
+        if (this.palette.field === 'heritage') {
+            colorKey.addClass("hidden");
+        } else {
+            colorKey.removeClass("hidden");
+        }
+        colorKey.css("background-color", selection.legend + alpha);
         formatted.find(".select2-selection-text").text(selection.text);
         return formatted;
     }

--- a/public/js/SpeciesFilter.js
+++ b/public/js/SpeciesFilter.js
@@ -29,6 +29,9 @@ var app = this.app || {};
         if (hashmap.has(tree_key)) {
             var currentCount = hashmap.get(tree_key);
             currentCount['count'] += 1;
+            if (tree.heritage) {
+                currentCount.heritage = true;
+            }
             hashmap.set(tree_key,  currentCount);
         }
         else {
@@ -41,6 +44,7 @@ var app = this.app || {};
                     familyBotanicalName: tree["family_name_botanical"],
                     nativity: tree.nativity,
                     iucnStatus: tree["iucn_status"],
+                    heritage: tree.heritage,
                 }
             );
         }
@@ -66,7 +70,8 @@ var app = this.app || {};
                 family_name_botanical: tree.familyBotanicalName, 
                 name_common: tree.commonName, 
                 nativity: tree.nativity, 
-                iucn_status: tree.iucnStatus
+                iucn_status: tree.iucnStatus,
+                heritage: tree.heritage,
             })
         );
         return Array.from(selectArray).sort(treeCompareAlpha);


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #208 

# Screenshots
![image](https://user-images.githubusercontent.com/20414905/66565419-28a13080-ebae-11e9-9751-949eb818b8b0.png)

# What I did
- heritage group filter emphasizes heritage markers (you can tweak color and size in the palette to what you consider appropriate)

- select2 color keys and off-screen auto zoom works with heritage group filter

- not sure if this one is necessary (5286d2c) but I removed non-heritage tree markers when filtering species with heritage group filter (although they would have been white anyway). Depends on the context of the use case? Don't merge da0ad28 if you're not merging 5286d2c.