### PR TITLE
bugfix filtered marker under toolbar

### DIFF
--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -43,23 +43,23 @@ var app = this.app || {};
     var center = bounds.getCenter();
     var palette = this.palette;
     var closestDistance;
-    var closestPoint;
+    var closestLatLng;
 
     this.selected = selections;
     this.redraw();
-    this.markers.eachLayer(function(marker) {
-      if(selections.size > 0) {
+    if(selections.size > 0) {
+      this.markers.eachLayer(function(marker) {
         var position = marker.getLatLng();
         var distance = center.distanceTo(position);
         if (distance < closestDistance || !closestDistance) {
           if ( !(palette.field === 'heritage' && !marker.tree.heritage)) {
             closestDistance = distance;
-            closestPoint = L.latLng(position);
+            closestLatLng = position;
           }
         }
-      }
-    });
-    this.leafletMap.fitBounds(bounds.extend(closestPoint));
+      })
+    };
+    this.leafletMap.fitBounds(bounds.extend(closestLatLng));
     setMarkerSize.call(this, this.zoom);
   }
 

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -44,6 +44,8 @@ var app = this.app || {};
     var palette = this.palette;
     var closestDistance;
     var closestLatLng;
+    var yThreshold = 107;
+    var pad = 0;
 
     this.selected = selections;
     this.redraw();
@@ -57,9 +59,12 @@ var app = this.app || {};
             closestLatLng = position;
           }
         }
-      })
-    };
-    this.leafletMap.fitBounds(bounds.extend(closestLatLng));
+      });
+      if (this.leafletMap.latLngToContainerPoint(closestLatLng).y < yThreshold) {
+        pad = yThreshold;
+      }
+    }
+    this.leafletMap.fitBounds(bounds.extend(closestLatLng), {paddingTopLeft: [0, pad]});
     setMarkerSize.call(this, this.zoom);
   }
 


### PR DESCRIPTION
# Motivation and context
When ensuring a filtered marker is in view, it is sometimes hidden under the toolbar

# What I did
- when the closest marker is above (visually) a specified y-coordinate threshold, padding is added

# Screenshots
current threshold set (if the marker was a single pixel higher the view would zoom out more to include the section above where it is now):
![image](https://user-images.githubusercontent.com/20414905/68067554-ca2a3500-fd9c-11e9-9e35-1fdb7ac35cdf.png)



