### PR TITLE
Hide orientation warning

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -59,17 +59,6 @@ var app = this.app || {};
     firstTimeDialog.classList.remove("hidden");
   }
 
-  
-
-  function detectMobileOrientation() {
-    window.addEventListener("orientationchange", function() {
-      if (window.matchMedia("(orientation: portrait)").matches) {
-        // you're in LANDSCAPE mode
-        alert('Please switch to portrait mode.');
-     }
-    }, false);
-    
-  }
 
   // EXPORTS
   module.init = init;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -21,7 +21,6 @@ var app = this.app || {};
       .then(function(response) {
         return response.json().then(function(trees) {
           setData(trees);
-          detectMobileOrientation();
         });
       });
   }


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #256 <!-- issue number here -->

# Motivation and context
right now, the warning is out of sync for iphone users (it appears when the user is viewing the site in portrait, not landscape). as a result, the pop up warning to switch the phone's orientation is annoying to users (more so it seems than is the site's imperfect appearance in landscape view)<!-- please describe what problem your issue is solving -->

# What I did
- remove mobile window orientation detection and the pop up warning <!-- list summary of changes made in this PR -->
