### PR TITLE
Vacant formatting

### DIFF
--- a/public/css/mobile/sidebar.css
+++ b/public/css/mobile/sidebar.css
@@ -1,15 +1,16 @@
 #sidebar-image > *,
-#sidebar-content > * {
+#sidebar-content > *,
+#sidebar-vacant-content > * {
   display: none;
 }
 
-#sidebar {
+#sidebar, #sidebar-vacant {
   height: 25%;
   width: 100%;
   transition: .5s ease;
 }
 
-#sidebar > div {
+#sidebar > div, #sidebar-vacant > div {
   background-color: white;
 }
 
@@ -25,11 +26,13 @@
 }
 
 #sidebar-content #sidebar-common-name,
-#sidebar-content #sidebar-address {
+#sidebar-content #sidebar-address,
+#sidebar-vacant-content #sidebar-vacant-common-name,
+#sidebar-vacant-content #sidebar-vacant-address {
   display: block;
 }
 
-#sidebar-content {
+#sidebar-content, #sidebar-vacant-content {
   padding: 16px;
 }
 
@@ -38,7 +41,7 @@
   display: none;
 }
 
-#sidebar-content .btn--mobile {
+#sidebar-content .btn--mobile, #sidebar-vacant-content .btn--mobile {
   display: block;
 }
 
@@ -53,7 +56,7 @@
   overflow: hidden;
 }
 
-.sidebar-mobile--fullscreen #sidebar {
+.sidebar-mobile--fullscreen #sidebar, #sidebar-vacant {
   height: 100vh;
 }
 
@@ -66,7 +69,8 @@
   font-size: 24px;
 }
 .sidebar-mobile--fullscreen #sidebar-image > *,
-.sidebar-mobile--fullscreen #sidebar-content > * {
+.sidebar-mobile--fullscreen #sidebar-content > *,
+.sidebar-mobile--fullscreen #sidebar-vacant-content > * {
   display: block;
 }
 
@@ -74,7 +78,8 @@
   display: flex;
 }
 
-.sidebar-mobile--fullscreen #sidebar-tree {
+.sidebar-mobile--fullscreen #sidebar-tree,
+.sidebar-mobile--fullscreen #sidebar {
   flex-direction: column;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -87,24 +87,44 @@
         </button>
         <div id="sidebar-vacant-content">
           <h1 id="sidebar-vacant-common-name"></h1>
-          <h5>Tree ID: <span id="sidebar-vacant-tree-id"></h5>
+          <h2>No tree at this site! Want to request a tree?</h2>
+          <div class="sidebar-divider"></div>
+          <div class="share-buttons">
+            <h5>Share this vacant site</h5>
+            <div class="a2a_kit a2a_kit_size_32 a2a_default_style">
+
+                <a class="a2a_button_facebook">
+                    <img src="icons/facebook-icon-white-copy@3x.png" border="0" alt="Facebook" width="20" height="20">
+                </a>
+                <a class="a2a_button_twitter">
+                    <img src="icons/twitter-icon-white-copy@3x.png" border="0" alt="Facebook" width="20" height="20">
+                </a>
+                <a class="a2a_button_email">
+                  <img src="icons/email-icon@3x.png" border="0" alt="Email" width="20" height="20"></img>
+                </a>
+                <!--<a class="a2a_button_copy_link"></a> NO SVG PROVIDED-->
+            </div>
+          </div>
+          <div class="sidebar-divider"></div>
           <button id="sidebar-vacant-details-button" class="btn btn--mobile">View Details</button>
           <div class="sidebar-details">
-            <h5>Nearest address: <span id="sidebar-vacant-address"></h5>
-            <p>This tree is not a tree! Placeholder text for a vacant site.</p>
-            <table class = 'sidebar-details'>
-              <tr>
-                <td>Planting Year:</td>
-                <td id="sidebar-vacant-pruning-year"></td>
-              </tr>
-              <tr>
-                <td>Replacement Species:</td>
-                <td id="sidebar-vacant-replacement-species"></td>
-              </tr>
-              <tr>
-                <td>Street Segment:</td>
-                <td id="sidebar-vacant-street-segment"></td>
-              </tr>
+          <h5>Location</h5>
+          <h4>NEAREST ADDRESS:</h4>
+          <span id="sidebar-vacant-address"></span>
+          <div class="sidebar-seperator"></div>
+          <h4>TREE ID:</h4>
+          <span id="sidebar-vacant-tree-id"></span>
+          <div class="sidebar-seperator"></div>
+          <div class="sidebar-divider"></div>
+          <h5>Conservation & Care</h5>
+          <h4>PLANTING YEAR:</h4>
+          <span id="sidebar-vacant-pruning-year"></span>
+          <div class="sidebar-seperator"></div>
+          <h4>PROPOSED SPECIES:</h4>
+          <span id="sidebar-vacant-replacement-species"></span>
+          <div class="sidebar-seperator"></div>
+          <h4>STREET SEGMENT:</h4>
+          <span id="sidebar-vacant-street-segment"></span>
             </table>
           </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -82,8 +82,9 @@
     <div id="sidebar">
       <div class="banner">SANTA MONICA PUBLIC TREE MAP</div>
       <div id="sidebar-vacant">
-        <button id="sidebar-vacant-close-button" class="btn-close">
-          <img src="./icons/close-btn-dark.svg" alt="close" />
+        <button id="sidebar-vacant-close-button" class = "btn-close">
+          <img src="./icons/close-btn-dark.svg" alt="close" class="btn-close--dark"/>
+          <img src="./icons/close-btn-light.svg" alt="close" class="btn-close--light"/>
         </button>
         <div id="sidebar-vacant-content">
           <h1 id="sidebar-vacant-common-name"></h1>
@@ -106,11 +107,10 @@
             </div>
           </div>
           <div class="sidebar-divider"></div>
-          <button id="sidebar-vacant-details-button" class="btn btn--mobile">View Details</button>
-          <div class="sidebar-details">
           <h5>Location</h5>
           <h4>NEAREST ADDRESS:</h4>
           <span id="sidebar-vacant-address"></span>
+          <button id="sidebar-vacant-details-button" class="btn btn--mobile">View Details</button>
           <div class="sidebar-seperator"></div>
           <h4>TREE ID:</h4>
           <span id="sidebar-vacant-tree-id"></span>
@@ -125,8 +125,6 @@
           <div class="sidebar-seperator"></div>
           <h4>STREET SEGMENT:</h4>
           <span id="sidebar-vacant-street-segment"></span>
-            </table>
-          </div>
         </div>
       </div>
       <div id="sidebar-tree">

--- a/public/js/Sidebar.js
+++ b/public/js/Sidebar.js
@@ -123,7 +123,8 @@ var initialY = null;
     this.pruningYear.innerText            = tree.pruning_year;
     this.replacementSpecies.innerHTML     = `<em>${tree.replacement_species}</em>`;
     this.address.innerText                = tree.address;
-    this.address.classList.add("sidebar-address-small")
+    this.address.classList.add("sidebar-address-small");
+    this.vacantAddress.classList.add("sidebar-address-small");
     this.streetSegment.innerText          = tree.segment;
 
     if (tree.images && tree.images.length > 1) {
@@ -188,14 +189,16 @@ var initialY = null;
       this.detailsButton.innerText = "View Details";
       this.vacantDetailsButton.innerText = "View Details";
       this.exploreMapButton.innerText = "What is Public Tree Map?";
-      this.address.classList.add("sidebar-address-small")
+      this.address.classList.add("sidebar-address-small");
+      this.vacantAddress.classList.add("sidebar-address-small");
     }
     else {
       this.body.classList.add(className);
       this.detailsButton.classList.add('hidden');
       this.vacantDetailsButton.classList.add('hidden');
       this.exploreMapButton.innerText = "Explore the Map";
-      this.address.classList.remove("sidebar-address-small")
+      this.address.classList.remove("sidebar-address-small");
+      this.vacantAddress.classList.remove("sidebar-address-small");
     }
   }
 


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #201

# Motivation and context
updates formatting for vacant site sidebars in mobile and desktop views.

# Screenshots
before:
mobile:
![Screen Shot 2020-02-10 at 8 15 02 PM](https://user-images.githubusercontent.com/22624609/74210838-32ad6b80-4c42-11ea-8da6-a518952f12e1.png)
desktop:
![Screen Shot 2020-02-10 at 8 12 06 PM](https://user-images.githubusercontent.com/22624609/74210840-33de9880-4c42-11ea-801a-fba1f74b2f7a.png)
after:
mobile:
![Screen Shot 2020-02-10 at 8 11 09 PM](https://user-images.githubusercontent.com/22624609/74210955-a5b6e200-4c42-11ea-92cd-80e70ba590dd.png)
desktop:
![Screen Shot 2020-02-10 at 8 11 18 PM](https://user-images.githubusercontent.com/22624609/74210943-99328980-4c42-11ea-9021-7b6ef9505e3c.png)

# What @isabelle-wagenvoord and I did
- match formatting for 5 vacant categories in sidebar.css and index.html
