### PR TITLE
fix mobile popup display

### DIFF
--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -139,7 +139,7 @@ var app = this.app || {};
       }
 
       marker.tree = tree;
-      marker.bindPopup(tree.name_common, {closeButton: false, minWidth:0}); 
+      marker.bindPopup(tree.name_common, {closeButton: false, minWidth:0, offset:[0,-2]}); 
       marker.on('mouseover', function (e) {
           this.openPopup();
       });

--- a/public/js/Map.js
+++ b/public/js/Map.js
@@ -139,7 +139,7 @@ var app = this.app || {};
       }
 
       marker.tree = tree;
-      marker.bindPopup(tree.name_common, {closeButton: false, offset:[0,-2]}); //offset moves popup up
+      marker.bindPopup(tree.name_common, {closeButton: false, minWidth:0}); 
       marker.on('mouseover', function (e) {
           this.openPopup();
       });


### PR DESCRIPTION
resolves #225


# Screenshots
| before | after |
|![Screen Shot 2020-04-23 at 12 13 46 AM](https://user-images.githubusercontent.com/24775373/80070554-f88cff80-84f7-11ea-8eec-1f30e4ab2f3c.png)|
![Screen Shot 2020-04-23 at 12 11 13 AM](https://user-images.githubusercontent.com/24775373/80070596-09d60c00-84f8-11ea-9586-6f55e1168c23.png)
|


# What I did
this problem is caused by the default minWidth setting of Leaflet popUp. Overriding the default setting to 0 fixes the problem.


