### PR TITLE
fix sidebar image display

### DIFF
--- a/public/js/Sidebar.js
+++ b/public/js/Sidebar.js
@@ -129,12 +129,12 @@ var initialY = null;
     this.vacantAddress.classList.add("sidebar-address-small");
     this.streetSegment.innerText          = tree.segment;
 
-    if (tree.images && tree.images.length > 1) {
-      this.image.style.backgroundImage = 'url(' + tree.images[1].url + ')';
+    if (tree.images && tree.images.length > 0) {
+      this.image.style.backgroundImage = 'url(' + tree.images[0].url + ')';
       this.image.style.backgroundSize = 'cover';
       this.image.classList.remove('hidden');
 
-      this.imageCreditLink.href = tree.images[1].author.url;
+      this.imageCreditLink.href = tree.images[0].author.url;
       images = tree.images;
     } else {
       this.image.style.backgroundImage = '';


### PR DESCRIPTION
Fixed [this](https://github.com/Public-Tree-Map/public-tree-map-data-pipeline/issues/63) in the data repo.
Pretty much just an array indexing problem. 

(Side effect: the default image for every single tree is now a different one)

# Screenshots
before
![Screen Shot 2020-05-21 at 11 22 05 AM](https://user-images.githubusercontent.com/24775373/82592216-6e1ad880-9b55-11ea-89fd-966615875fb9.png)

after
![Screen Shot 2020-05-21 at 11 21 37 AM](https://user-images.githubusercontent.com/24775373/82592238-7541e680-9b55-11ea-8907-55a659d752de.png)



