### PR TITLE
update mobile toolbar

### DIFF
--- a/public/css/mobile/toolbar.css
+++ b/public/css/mobile/toolbar.css
@@ -29,7 +29,7 @@
     padding-right: 0;
 }
 
-#species-button-species, #species-button-family {
+#species-button-species, #species-button-heritage {
   display: block;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,7 @@
           <label class="toolbar-label">VIEW</label>
           <div id="color-filter" class="btn-group">
             <button id="species-button-species" class="species-button active" value="name_common">Species</button>
-            <button id="species-button-family" class="species-button" value="family_name_botanical">Family</button>
+            <button id="species-button-family" class="species-button" value="family_name_botanical">Families</button>
             <button class="species-button" value="nativity">CA Native</button>
             <button id="species-button-heritage" class="species-button" value="heritage">Heritage</button>
             <button class="species-button" value="iucn_status">Endangered</button>

--- a/public/index.html
+++ b/public/index.html
@@ -63,7 +63,7 @@
         </div>
         <!-- Color Filter -->
         <div class="color-filter-container">
-          <label class="toolbar-label">GROUP BY</label>
+          <label class="toolbar-label">VIEW</label>
           <div id="color-filter" class="btn-group">
             <button id="species-button-species" class="species-button active" value="name_common">Species</button>
             <button id="species-button-family" class="species-button" value="family_name_botanical">Family</button>


### PR DESCRIPTION
# Motivation and context
<!-- please describe what problem your issue is solving -->
**temporary fix**
On the current mobile site, only two view options are available (species and family). Since the heritage tree program's a city public landscape priority, I'm switching the family button to a heritage button. In the future, it'd be great to give mobile users access to more than two views (it's on the list of design questions)

related:
I also think it might make sense to change "GROUP BY" to "VIEW BY"
If non heritage trees are fully hidden in heritage view (rather than just given white markers), would user experience improve?

# Screenshots
| before | after |
|---|---|
| ![Screen Shot 2020-05-24 at 1 22 49 PM](https://user-images.githubusercontent.com/22624609/82764178-c0f8c800-9dc1-11ea-9f58-0737d3d9e4de.png)<!-- before screenshot here --> | ![Screen Shot 2020-05-24 at 1 23 10 PM](https://user-images.githubusercontent.com/22624609/82764179-c1915e80-9dc1-11ea-9b59-a53f24c4d773.png)<!-- after screenshot here --> |

# What I did
- <!-- list summary of changes made in this PR --> switched family button to heritage button in mobile toolbar.css