### PR TITLE
CA native mobile button

### DIFF
--- a/public/css/mobile/toolbar.css
+++ b/public/css/mobile/toolbar.css
@@ -40,10 +40,10 @@
     min-width: 125px;
 }
 
-#species-button-species, #species-button-heritage {
+#species-button-species, #species-button-native {
   display: inline-block;
 }
-#species-button-heritage {
+#species-button {
   border-radius: 0 4px 4px 0;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -63,13 +63,13 @@
         </div>
         <!-- Color Filter -->
         <div class="color-filter-container">
-          <label class="toolbar-label">VIEW</label>
+          <label class="toolbar-label">GROUP BY</label>
           <div id="color-filter" class="btn-group">
             <button id="species-button-species" class="species-button active" value="name_common">Species</button>
             <button id="species-button-family" class="species-button" value="family_name_botanical">Families</button>
-            <button class="species-button" value="nativity">CA Native</button>
-            <button id="species-button-heritage" class="species-button" value="heritage">Heritage</button>
-            <button class="species-button" value="iucn_status">Endangered</button>
+            <button id="species-button-native" class="species-button" value="nativity">Native</button>
+            <button id="species-button-heritage" class="species-button" value="heritage">SM Heritage</button>
+            <button id="species-button-IUCN" class="species-button" value="iucn_status">Endangered</button>
           </div>
         </div>
         <div class="species-filter-container">

--- a/public/js/Palettes.js
+++ b/public/js/Palettes.js
@@ -6,11 +6,11 @@ var app = this.app || {};
     'nativity': {
       'generated': false,
       'field'    : 'nativity',
-      'native'   : { 'color': '#40AD75', 'title': 'Native to California' },
-      'exotic'   : { 'color': '#fc9272', 'title': 'Not Native to California' },
-      'moderate' : { 'color': '#BC0000', 'title': 'Moderate' },
-      'watch'    : { 'color': '#FF8202', 'title': 'Watch' },
-      'limited'  : { 'color': '#FE0000', 'title': 'Limited' },
+      'native'   : { 'color': '#55A860', 'title': 'Native to California' },
+      'exotic'   : { 'color': '#fdbaa3', 'title': 'Not Native to California' },
+      'moderate' : { 'color': '#fdbaa3', 'title': 'Moderate' },
+      'watch'    : { 'color': '#fdbaa3', 'title': 'Watch' },
+      'limited'  : { 'color': '#fdbaa3', 'title': 'Limited' },
       'default'  : '#bdbdbd'
     },
     'name_common': {


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
addresses #150 <!-- issue number here -->

# Motivation and context
<!-- please describe what problem your issue is solving -->
I'd like to use the mobile button toggle to allow users to find the limited number of public trees native to CA floristic province

# Screenshots 
(testing as iphoneX - issue with white bottom border documented in #245)

before:
![Screen Shot 2020-06-14 at 9 39 43 AM](https://user-images.githubusercontent.com/22624609/84599158-b495e700-ae24-11ea-82dd-990f1325bd70.png)

after:
![Screen Shot 2020-06-14 at 9 38 54 AM](https://user-images.githubusercontent.com/22624609/84599153-b069c980-ae24-11ea-9216-1997841d9c85.png)

# What I did
<!-- list summary of changes made in this PR -->
- switch the mobile toggle from species / SM heritage to species / native

- update native color palette (to try to improve legibility) - color blind safe according to colorbrewer
