### PR TITLE
GitHub Action to deploy site to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,25 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        # with actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work.
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Copy CNAME
+        run: cp CNAME public/
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: public # The folder the action should deploy.


### PR DESCRIPTION
This GitHub Action runs on a push to `master`. The contents of the `public/` folder, as well as the `CNAME` file, are copied to the `gh-pages` branch.

Resolves #297 

*Note*: The action will create the `gh-pages` branch if it does not already exist.
