### PR TITLE
Update placeholder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -269,7 +269,7 @@
       </div>
       <div id="sidebar-default">
         <h1>Explore Our Urban Forest</h1>
-        <div class = 'sidebar-details'>Every public tree is a civic resource. The city of Santa Monica provides a public dataset describing the properties of all 35,000 public park and street trees in the city. Our goal is to provide a map that lets you view, filter, and explore the data. This website is built and maintained by volunteers. If you notice a problem or would like to requests a feature, please let us know!
+        <div class = 'sidebar-details'>Every public tree is a civic resource. The city of Santa Monica provides a public dataset describing the properties of all 35,000 public park and street trees in the city. Our goal is to provide a map that lets you view, filter, and explore the data. This website is built and maintained by volunteers. If you notice a problem or would like to request a feature, <a target="_blank" rel="noopener noreferrer" href = "https://github.com/Public-Tree-Map/public-tree-map/issues/new/choose">please let us know!</a>
         </div>
         <div class="sidebar-seperator"></div>
         <h5><a target="_blank" rel="noopener noreferrer" href = "https://public-tree-map.github.io/">About</a>  |  <a target="_blank" rel="noopener noreferrer" href="https://github.com/Public-Tree-Map/public-tree-map/issues/new/choose">Feedback</a>  |  <a target="_blank" rel="noopener noreferrer" href = "https://github.com/Public-Tree-Map/public-tree-map-data-pipeline#data-sources">Data Sources</a> |  <a target="_blank" rel="noopener noreferrer" href = "https://www.instagram.com/publictreemap/">Instagram</a></h5>

--- a/public/index.html
+++ b/public/index.html
@@ -269,7 +269,7 @@
       </div>
       <div id="sidebar-default">
         <h1>Explore Our Urban Forest</h1>
-        <div class = 'sidebar-details'>Every public tree is a civic resource. Public Tree Map uses open datasets to documents information about each of Santa Monica's nearly 35,000 public park and street trees. 
+        <div class = 'sidebar-details'>Every public tree is a civic resource. The city of Santa Monica provides a public dataset describing the properties of all 35,000 public park and street trees in the city. Our goal is to provide a map that lets you view, filter, and explore the data. If you notice a problem or would like to requests a feature, please let us know!
         </div>
         <div class="sidebar-seperator"></div>
         <h5><a target="_blank" rel="noopener noreferrer" href = "https://public-tree-map.github.io/">About</a>  |  <a target="_blank" rel="noopener noreferrer" href="https://github.com/Public-Tree-Map/public-tree-map/issues/new/choose">Feedback</a>  |  <a target="_blank" rel="noopener noreferrer" href = "https://github.com/Public-Tree-Map/public-tree-map-data-pipeline#data-sources">Data Sources</a> |  <a target="_blank" rel="noopener noreferrer" href = "https://www.instagram.com/publictreemap/">Instagram</a></h5>

--- a/public/index.html
+++ b/public/index.html
@@ -269,7 +269,7 @@
       </div>
       <div id="sidebar-default">
         <h1>Explore Our Urban Forest</h1>
-        <div class = 'sidebar-details'>Every public tree is a civic resource. The city of Santa Monica provides a public dataset describing the properties of all 35,000 public park and street trees in the city. Our goal is to provide a map that lets you view, filter, and explore the data. If you notice a problem or would like to requests a feature, please let us know!
+        <div class = 'sidebar-details'>Every public tree is a civic resource. The city of Santa Monica provides a public dataset describing the properties of all 35,000 public park and street trees in the city. Our goal is to provide a map that lets you view, filter, and explore the data. This website is built and maintained by volunteers. If you notice a problem or would like to requests a feature, please let us know!
         </div>
         <div class="sidebar-seperator"></div>
         <h5><a target="_blank" rel="noopener noreferrer" href = "https://public-tree-map.github.io/">About</a>  |  <a target="_blank" rel="noopener noreferrer" href="https://github.com/Public-Tree-Map/public-tree-map/issues/new/choose">Feedback</a>  |  <a target="_blank" rel="noopener noreferrer" href = "https://github.com/Public-Tree-Map/public-tree-map-data-pipeline#data-sources">Data Sources</a> |  <a target="_blank" rel="noopener noreferrer" href = "https://www.instagram.com/publictreemap/">Instagram</a></h5>


### PR DESCRIPTION
# Motivation and context
I noticed a typo in the placeholder text that appears on the website. I made an update to that text and added a couple of sentences.



# Screenshots
| before | after |
|---|---|
| <!-- before screenshot here -->![Screen Shot 2020-07-02 at 6 17 44 AM](https://user-images.githubusercontent.com/22624609/86363527-d61c0e80-bc2b-11ea-97fb-8635346e28f6.png) | <!-- after screenshot here -->![Screen Shot 2020-07-02 at 6 17 30 AM](https://user-images.githubusercontent.com/22624609/86363557-e0d6a380-bc2b-11ea-8246-e46fbd7f31d1.png) |

# What I did
- change text in index.html <!-- list summary of changes made in this PR -->
